### PR TITLE
feat: theme toggle, import/export modal, confirmations, hotkeys, toasts

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "reactflow/dist/style.css";
 import "./globals.css";
+import { ToastProvider } from "@/components/Toast";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,11 +26,19 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `try{if(localStorage.getItem('theme')==='dark'){document.documentElement.classList.add('dark')}}catch(e){}`,
+          }}
+        />
+      </head>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <ToastProvider>
+          <ThemeToggle />
+          {children}
+        </ToastProvider>
       </body>
     </html>
   );

--- a/src/components/ImportExportModal.tsx
+++ b/src/components/ImportExportModal.tsx
@@ -1,0 +1,117 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Node, Edge } from "reactflow";
+import type { CRTNodeData } from "./NodeView";
+import type { CRTEdgeData } from "./Toolbar";
+import { useToast } from "./Toast";
+
+export function ImportExportModal({
+  open,
+  onClose,
+  graph,
+  onImport,
+}: {
+  open: boolean;
+  onClose: () => void;
+  graph: string;
+  onImport: (data: { nodes: Node<CRTNodeData>[]; edges: Edge<CRTEdgeData>[] }) => void;
+}) {
+  const toast = useToast();
+  const [tab, setTab] = useState<"export" | "import">("export");
+  const [text, setText] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setTab("export");
+      setText("");
+      setError("");
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(graph);
+      toast("Экспорт скопирован");
+    } catch {}
+  };
+
+  const handleImport = () => {
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed.nodes && parsed.edges) {
+        onImport(parsed);
+        toast("Импорт выполнен");
+        onClose();
+        return;
+      }
+      throw new Error("invalid");
+    } catch {
+      setError("Некорректный JSON");
+      toast("Ошибка импорта");
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-lg rounded-xl border bg-white p-4 shadow-lg dark:border-neutral-700 dark:bg-neutral-900">
+        <div className="mb-4 flex border-b dark:border-neutral-700">
+          <button
+            className={`flex-1 pb-2 text-sm ${tab === "export" ? "border-b-2 font-semibold border-blue-500" : "text-neutral-500"}`}
+            onClick={() => setTab("export")}
+          >
+            Экспорт
+          </button>
+          <button
+            className={`flex-1 pb-2 text-sm ${tab === "import" ? "border-b-2 font-semibold border-blue-500" : "text-neutral-500"}`}
+            onClick={() => setTab("import")}
+          >
+            Импорт
+          </button>
+        </div>
+        {tab === "export" ? (
+          <div>
+            <textarea
+              readOnly
+              value={graph}
+              className="h-64 w-full rounded border p-2 text-xs font-mono dark:border-neutral-700 dark:bg-neutral-950"
+            />
+            <div className="mt-2 flex justify-end">
+              <button
+                onClick={handleCopy}
+                className="rounded border px-3 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+              >
+                Скопировать
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <textarea
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              className="h-64 w-full rounded border p-2 text-xs font-mono dark:border-neutral-700 dark:bg-neutral-950"
+            />
+            {error && <div className="mt-1 text-xs text-red-500">{error}</div>}
+            <div className="mt-2 flex justify-end">
+              <button
+                onClick={handleImport}
+                className="rounded border px-3 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+              >
+                Загрузить
+              </button>
+            </div>
+          </div>
+        )}
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-4 text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem("theme");
+      if (saved === "dark") {
+        setTheme("dark");
+        document.documentElement.classList.add("dark");
+      }
+    } catch {}
+  }, []);
+
+  const toggle = () => {
+    const next = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    try {
+      localStorage.setItem("theme", next);
+    } catch {}
+    document.documentElement.classList.toggle("dark", next === "dark");
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      className="fixed right-3 top-3 z-50 rounded-full border border-neutral-300 bg-white p-2 text-xs shadow-sm hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:bg-neutral-800"
+      title="Переключить тему"
+    >
+      {theme === "dark" ? "🌙" : "☀️"}
+    </button>
+  );
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { createContext, useContext, useState, ReactNode } from "react";
+
+const ToastContext = createContext<(msg: string) => void>(() => {});
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<{ id: number; message: string }[]>([]);
+
+  const notify = (message: string) => {
+    const id = Date.now();
+    setToasts((t) => [...t, { id, message }]);
+    setTimeout(() => {
+      setToasts((t) => t.filter((toast) => toast.id !== id));
+    }, 3000);
+  };
+
+  return (
+    <ToastContext.Provider value={notify}>
+      {children}
+      <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className="rounded bg-neutral-800 px-3 py-2 text-sm text-white shadow dark:bg-neutral-700"
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  return useContext(ToastContext);
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -9,6 +9,14 @@ const categoryStyle: Record<CRTNodeCategory, string> = {
   Note: "from-stone-500 to-neutral-600",
 };
 
+const categoryLabel: Record<CRTNodeCategory, string> = {
+  UDE: "Нежелательный эффект",
+  Cause: "Причина",
+  RootCause: "Корневая причина",
+  Injection: "Инъекция",
+  Note: "Заметка",
+};
+
 export type CRTEdgeKind = "sufficiency" | "assumption";
 export type CRTEdgeData = { kind: CRTEdgeKind };
 
@@ -16,15 +24,13 @@ export function Toolbar({
   edgeKind,
   setEdgeKind,
   onClear,
-  onExport,
-  onImport,
+  onOpenImportExport,
   onAutoLayout,
 }: {
   edgeKind: CRTEdgeKind;
   setEdgeKind: (k: CRTEdgeKind) => void;
   onClear: () => void;
-  onExport: () => void;
-  onImport: (file: File) => void;
+  onOpenImportExport: () => void;
   onAutoLayout: () => void;
 }) {
   const handleDragStart = (e: React.DragEvent, category: CRTNodeCategory) => {
@@ -46,7 +52,7 @@ export function Toolbar({
             className={`cursor-grab select-none rounded-xl bg-gradient-to-br ${categoryStyle[c]} p-2 text-center text-xs font-bold text-white shadow active:cursor-grabbing`}
             title="Перетащите на холст"
           >
-            {c}
+            {categoryLabel[c]}
           </div>
         ))}
       </div>
@@ -70,25 +76,13 @@ export function Toolbar({
         <button onClick={onClear} className="rounded-xl border border-red-200 bg-white px-3 py-2 text-xs font-semibold text-red-600 shadow-sm hover:bg-red-50 dark:border-red-800/50 dark:bg-neutral-900 dark:hover:bg-neutral-800">
           Очистить
         </button>
-        <button onClick={onExport} className="rounded-xl border border-neutral-300 bg-white px-3 py-2 text-xs font-semibold shadow-sm hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:bg-neutral-800">
-          Экспорт JSON
+        <button onClick={onOpenImportExport} className="col-span-2 rounded-xl border border-neutral-300 bg-white px-3 py-2 text-xs font-semibold shadow-sm hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:bg-neutral-800">
+          Импорт/Экспорт
         </button>
-        <label className="inline-flex cursor-pointer items-center justify-center rounded-xl border border-neutral-300 bg-white px-3 py-2 text-xs font-semibold shadow-sm hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:bg-neutral-800">
-          Импорт JSON
-          <input
-            type="file"
-            accept="application/json"
-            className="hidden"
-            onChange={(e) => {
-              const f = e.target.files?.[0];
-              if (f) onImport(f);
-            }}
-          />
-        </label>
       </div>
 
       <p className="mt-3 text-[10px] leading-tight text-neutral-500 dark:text-neutral-400">
-        Подсказка: перетащите тип узла на холст. Соединяйте узлы мышью. Delete — удалить выделенное, Ctrl/Cmd+S — сохранить локально.
+        Подсказка: перетщите тип узла на холст. Соединяйте узлы мышью. Delete — удалить выделенное, Ctrl/Cmd+S — сохранить локально. Ctrl/Cmd+O — импорт/экспорт, Ctrl/Cmd+E — копировать JSON.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- add persistent theme toggle and global toast provider
- replace export/import buttons with modal and russian labels
- add keyboard shortcuts, confirmations, and toast notifications

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689d9cdc82d8832b8e9abea5b38d3a43