### PR TITLE
feat: extend CRT editor with AND nodes and power-user tools

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ReactFlow, {
   Background,
   Controls,
@@ -17,15 +17,17 @@ import ReactFlow, {
   ReactFlowInstance,
 } from "reactflow";
 import CrtNode from "@/components/nodes/CrtNode";
+import AndNode from "@/components/nodes/AndNode";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import type { CRTNodeData } from "@/components/NodeView";
 import { Toolbar, CRTEdgeKind, CRTEdgeData } from "@/components/Toolbar";
 import { Inspector } from "@/components/Inspector";
 import { ImportExportModal } from "@/components/ImportExportModal";
 import { useToast } from "@/components/Toast";
+import { ValidationPanel } from "@/components/ValidationPanel";
 import * as dagre from "dagre";
 
-type CRTNode = Node<CRTNodeData>;
+type CRTNode = Node; // allow mixed node types
 
 type Project = {
   id: string;
@@ -37,7 +39,7 @@ type Project = {
 const LS_PROJECTS_KEY = "crt_projects_v1";
 const LS_ACTIVE_ID_KEY = "crt_active_project_v1";
 
-const nodeTypes = { crt: CrtNode };
+const nodeTypes = { crt: CrtNode, and: AndNode };
 
 let idSeq = 1;
 const nextId = () => `${Date.now().toString(36)}_${idSeq++}`;
@@ -88,11 +90,23 @@ const createExampleData = () => {
 };
 
 export default function Page() {
-  const [nodes, setNodes, onNodesChange] = useNodesState<CRTNodeData>([]);
+  type GraphNodeData = CRTNodeData | Record<string, never>;
+  const [nodes, setNodes, onNodesChange] = useNodesState<GraphNodeData>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<CRTEdgeData>([]);
   const [rf, setRf] = useState<ReactFlowInstance | null>(null);
   const [edgeKind, setEdgeKind] = useState<CRTEdgeKind>("sufficiency");
-  const [selection, setSelection] = useState<{ node?: Node<CRTNodeData>; edge?: Edge<CRTEdgeData> }>({});
+  const [selection, setSelection] = useState<{ nodes: Node[]; edges: Edge<CRTEdgeData>[] }>({ nodes: [], edges: [] });
+  const selectSingle = useCallback(
+    (sel: { node?: Node; edge?: Edge<CRTEdgeData> }) => {
+      setSelection({ nodes: sel.node ? [sel.node] : [], edges: sel.edge ? [sel.edge] : [] });
+    },
+    []
+  );
+  const [contextMenu, setContextMenu] = useState<
+    | { x: number; y: number; target: { type: "node" | "edge"; id: string } }
+    | null
+  >(null);
+  const [showValidation, setShowValidation] = useState(false);
   const [showIE, setShowIE] = useState(false);
   const toast = useToast();
   const [projects, setProjects] = useState<Project[]>([]);
@@ -101,6 +115,8 @@ export default function Page() {
   const [tempName, setTempName] = useState("");
 
   const graphJson = useMemo(() => JSON.stringify({ nodes, edges }, null, 2), [nodes, edges]);
+
+  const clipboard = useRef<{ nodes: Node[]; edges: Edge<CRTEdgeData>[] }>({ nodes: [], edges: [] });
 
   // initial/load
   useEffect(() => {
@@ -192,22 +208,52 @@ export default function Page() {
       if (!rf) return;
       const payload = event.dataTransfer.getData("application/reactflow");
       if (!payload) return;
-      let category: CRTNodeData["category"];
+      let parsed: { type?: string; category?: CRTNodeData["category"] };
       try {
-        ({ category } = JSON.parse(payload) as { category: CRTNodeData["category"] });
+        parsed = JSON.parse(payload);
       } catch {
         return;
       }
       const position = rf.screenToFlowPosition({ x: event.clientX, y: event.clientY });
-      const newNode: CRTNode = { id: nextId(), position, data: { title: "Новый узел", category, confidence: 100 }, type: "crt" };
-      setNodes((nds) => nds.concat(newNode));
+      if (parsed.type === "and") {
+        const newNode: CRTNode = { id: nextId(), position, data: {}, type: "and" };
+        setNodes((nds) => nds.concat(newNode));
+      } else if (parsed.category) {
+        const category: CRTNodeData["category"] = parsed.category;
+        const newNode: CRTNode = {
+          id: nextId(),
+          position,
+          data: { title: "Новый узел", category, confidence: 100 },
+          type: "crt",
+        };
+        setNodes((nds) => nds.concat(newNode));
+      }
     },
     [rf, setNodes]
   );
 
+  const onNodeDragStart = useCallback(
+    (event: React.MouseEvent, node: Node) => {
+      if (event.altKey) {
+        const clone: Node = {
+          ...node,
+          id: nextId(),
+          position: { x: node.position.x + 20, y: node.position.y + 20 },
+        };
+        setNodes((nds) => nds.concat(clone));
+        setSelection({ nodes: [clone], edges: [] });
+      }
+    },
+    [setNodes]
+  );
+
   const updateNode = useCallback(
     (id: string, data: Partial<CRTNodeData>) => {
-      setNodes((nds) => nds.map((n) => (n.id === id ? { ...n, data: { ...n.data, ...data } } : n)));
+      setNodes((nds) =>
+        nds.map((n) =>
+          n.id === id && n.type === "crt" ? { ...n, data: { ...n.data, ...data } } : n
+        )
+      );
     },
     [setNodes]
   );
@@ -219,22 +265,118 @@ export default function Page() {
     [setEdges]
   );
 
+  const deleteNodes = useCallback(
+    (ids: string[]) => {
+      setNodes((nds) => nds.filter((n) => !ids.includes(n.id)));
+      setEdges((eds) => eds.filter((e) => !ids.includes(e.source) && !ids.includes(e.target)));
+    },
+    [setNodes, setEdges]
+  );
+
+  const deleteEdges = useCallback(
+    (ids: string[]) => {
+      setEdges((eds) => eds.filter((e) => !ids.includes(e.id)));
+    },
+    [setEdges]
+  );
+
   const onDeleteSelected = useCallback(() => {
-    if (selection.node) {
-      const nodeId = selection.node.id;
-      setNodes((nds) => nds.filter((n) => n.id !== nodeId));
-      setEdges((eds) => eds.filter((e) => e.source !== nodeId && e.target !== nodeId));
-      setSelection({});
-    } else if (selection.edge) {
-      const edgeId = selection.edge.id;
-      setEdges((eds) => eds.filter((e) => e.id !== edgeId));
-      setSelection({});
+    if (selection.nodes.length) {
+      deleteNodes(selection.nodes.map((n) => n.id));
     }
-  }, [selection, setEdges, setNodes]);
+    if (selection.edges.length) {
+      deleteEdges(selection.edges.map((e) => e.id));
+    }
+    setSelection({ nodes: [], edges: [] });
+  }, [deleteEdges, deleteNodes, selection.edges, selection.nodes]);
+
+  const alignSelected = useCallback(
+    (mode: "left" | "centerX" | "right" | "top" | "middle" | "bottom") => {
+      const ids = selection.nodes.map((n) => n.id);
+      const xs = selection.nodes.map((n) => n.position.x);
+      const ys = selection.nodes.map((n) => n.position.y);
+      const left = Math.min(...xs);
+      const right = Math.max(...xs);
+      const top = Math.min(...ys);
+      const bottom = Math.max(...ys);
+      const centerX = (left + right) / 2;
+      const centerY = (top + bottom) / 2;
+      setNodes((nds) =>
+        nds.map((n) => {
+          if (!ids.includes(n.id)) return n;
+          const pos = { ...n.position };
+          switch (mode) {
+            case "left":
+              pos.x = left;
+              break;
+            case "centerX":
+              pos.x = centerX;
+              break;
+            case "right":
+              pos.x = right;
+              break;
+            case "top":
+              pos.y = top;
+              break;
+            case "middle":
+              pos.y = centerY;
+              break;
+            case "bottom":
+              pos.y = bottom;
+              break;
+          }
+          return { ...n, position: pos };
+        })
+      );
+    },
+    [selection.nodes, setNodes]
+  );
+
+  const duplicateNode = useCallback(
+    (id: string) => {
+      const original = nodes.find((n) => n.id === id);
+      if (!original) return;
+      const clone: Node = {
+        ...original,
+        id: nextId(),
+        position: { x: original.position.x + 40, y: original.position.y + 40 },
+      };
+      setNodes((nds) => nds.concat(clone));
+    },
+    [nodes, setNodes]
+  );
+
+  const changeType = useCallback(
+    (id: string) => {
+      const node = nodes.find((n) => n.id === id);
+      if (node && node.type === "crt") {
+        const next = window.prompt(
+          "Новый тип (UDE, Cause, RootCause, Injection, Note)",
+          (node.data as CRTNodeData).category
+        );
+        if (next) updateNode(id, { category: next as CRTNodeData["category"] });
+      }
+    },
+    [nodes, updateNode]
+  );
+
+  const quickTags = useCallback(
+    (id: string) => {
+      const node = nodes.find((n) => n.id === id);
+      if (node && node.type === "crt") {
+        const tags = window.prompt("Теги через запятую", (node.data as CRTNodeData).tags?.join(", ") ?? "");
+        if (tags !== null)
+          updateNode(id, {
+            tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
+          });
+      }
+    },
+    [nodes, updateNode]
+  );
 
   useEffect(() => {
     const h = (e: KeyboardEvent) => {
-      if ((e.key === "Backspace" || e.key === "Delete") && (selection.node || selection.edge)) {
+      if ((e.key === "Backspace" || e.key === "Delete") && (selection.nodes.length || selection.edges.length)) {
         e.preventDefault();
         onDeleteSelected();
       }
@@ -258,16 +400,51 @@ export default function Page() {
         navigator.clipboard.writeText(graphJson);
         toast("Экспорт скопирован");
       }
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "c") {
+        e.preventDefault();
+        const ids = selection.nodes.map((n) => n.id);
+        clipboard.current = {
+          nodes: selection.nodes.map((n) => ({ ...n, data: JSON.parse(JSON.stringify(n.data)) })),
+          edges: edges
+            .filter((ed) => ids.includes(ed.source) && ids.includes(ed.target))
+            .map((ed) => ({ ...ed, data: JSON.parse(JSON.stringify(ed.data)) })),
+        };
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "v") {
+        e.preventDefault();
+        const map = new Map<string, string>();
+        const newNodes = clipboard.current.nodes.map((n) => {
+          const id = nextId();
+          map.set(n.id, id);
+          return {
+            ...n,
+            id,
+            position: { x: n.position.x + 40, y: n.position.y + 40 },
+          };
+        });
+        const newEdges = clipboard.current.edges.map((e) => ({
+          ...e,
+          id: nextId(),
+          source: map.get(e.source) || e.source,
+          target: map.get(e.target) || e.target,
+        }));
+        if (newNodes.length) setNodes((nds) => nds.concat(newNodes));
+        if (newEdges.length) setEdges((eds) => eds.concat(newEdges));
+      }
+      if (!e.ctrlKey && !e.metaKey && e.key.toLowerCase() === "v") {
+        e.preventDefault();
+        setShowValidation((v) => !v);
+      }
     };
     window.addEventListener("keydown", h);
     return () => window.removeEventListener("keydown", h);
-  }, [graphJson, onDeleteSelected, selection.edge, selection.node, toast]);
+  }, [edges, graphJson, onDeleteSelected, selection.edges, selection.nodes, setEdges, setNodes, toast]);
 
   const onImportData = useCallback(
     ({ nodes: n, edges: e }: { nodes: CRTNode[]; edges: Edge<CRTEdgeData>[] }) => {
       setNodes(n);
       setEdges(e);
-      setSelection({});
+      setSelection({ nodes: [], edges: [] });
     },
     [setEdges, setNodes]
   );
@@ -284,7 +461,7 @@ export default function Page() {
       setActiveProjectId(proj.id);
       setNodes(n);
       setEdges(e);
-      setSelection({});
+      setSelection({ nodes: [], edges: [] });
     },
     [projects.length, setEdges, setNodes]
   );
@@ -293,7 +470,7 @@ export default function Page() {
     if (!window.confirm("Точно очистить холст? Действие необратимо.")) return;
     setNodes([]);
     setEdges([]);
-    setSelection({});
+    setSelection({ nodes: [], edges: [] });
     toast("Очистка выполнена");
   }, [setEdges, setNodes, toast]);
 
@@ -321,7 +498,7 @@ export default function Page() {
     if (proj) {
       setNodes(proj.data.nodes);
       setEdges(proj.data.edges);
-      setSelection({});
+      setSelection({ nodes: [], edges: [] });
     }
   };
 
@@ -337,7 +514,7 @@ export default function Page() {
     setActiveProjectId(proj.id);
     setNodes(data.nodes);
     setEdges(data.edges);
-    setSelection({});
+    setSelection({ nodes: [], edges: [] });
   };
 
   const startRename = () => {
@@ -366,7 +543,7 @@ export default function Page() {
       setActiveProjectId(next.id);
       setNodes(next.data.nodes);
       setEdges(next.data.edges);
-      setSelection({});
+      setSelection({ nodes: [], edges: [] });
     }
   };
 
@@ -386,7 +563,7 @@ export default function Page() {
     setActiveProjectId(clone.id);
     setNodes(clone.data.nodes);
     setEdges(clone.data.edges);
-    setSelection({});
+    setSelection({ nodes: [], edges: [] });
   };
 
   return (
@@ -439,6 +616,16 @@ export default function Page() {
           </button>
         </div>
       </div>
+      {selection.nodes.length >= 2 && (
+        <div className="pointer-events-auto fixed top-12 left-1/2 z-40 flex -translate-x-1/2 gap-1 rounded-2xl border bg-white/80 px-3 py-1 text-xs shadow backdrop-blur-md dark:border-neutral-800 dark:bg-neutral-900/80">
+          <button onClick={() => alignSelected("left")} className="px-1">L</button>
+          <button onClick={() => alignSelected("centerX")} className="px-1">C</button>
+          <button onClick={() => alignSelected("right")} className="px-1">R</button>
+          <button onClick={() => alignSelected("top")} className="px-1">T</button>
+          <button onClick={() => alignSelected("middle")} className="px-1">M</button>
+          <button onClick={() => alignSelected("bottom")} className="px-1">B</button>
+        </div>
+      )}
 
       <Toolbar
         edgeKind={edgeKind}
@@ -449,7 +636,19 @@ export default function Page() {
         onDuplicateProject={handleDuplicateProject}
       />
 
-      <Inspector selection={selection} updateNode={updateNode} updateEdge={updateEdge} />
+      <Inspector
+        selection={{ node: selection.nodes[0], edge: selection.edges[0] }}
+        updateNode={updateNode}
+        updateEdge={updateEdge}
+      />
+      <ValidationPanel
+        open={showValidation}
+        setOpen={setShowValidation}
+        nodes={nodes}
+        edges={edges}
+        rf={rf}
+        setSelection={selectSingle}
+      />
 
       <div className="h-full w-full">
         <ErrorBoundary>
@@ -464,7 +663,22 @@ export default function Page() {
             fitView
             onDrop={onDrop}
             onDragOver={onDragOver}
-            onSelectionChange={(s) => setSelection({ node: s.nodes[0] as Node<CRTNodeData>, edge: s.edges[0] as Edge<CRTEdgeData> })}
+            onSelectionChange={(s) =>
+              setSelection({ nodes: s.nodes as Node[], edges: s.edges as Edge<CRTEdgeData>[] })
+            }
+            onNodeContextMenu={(e, n) => {
+              e.preventDefault();
+              setContextMenu({ x: e.clientX, y: e.clientY, target: { type: "node", id: n.id } });
+            }}
+            onEdgeContextMenu={(e, ed) => {
+              e.preventDefault();
+              setContextMenu({ x: e.clientX, y: e.clientY, target: { type: "edge", id: ed.id } });
+            }}
+            onPaneClick={() => setContextMenu(null)}
+            onNodeDragStart={onNodeDragStart}
+            selectionOnDrag
+            snapToGrid
+            snapGrid={[20, 20]}
             proOptions={{ hideAttribution: true }}
           >
             <MiniMap zoomable pannable className="!bg-white/50 dark:!bg-neutral-950/60" />
@@ -481,6 +695,66 @@ export default function Page() {
         onImport={onImportData}
         onImportAsNew={onImportAsNew}
       />
+      {contextMenu && (
+        <div
+          className="fixed z-50 rounded-md border bg-white text-xs shadow dark:border-neutral-700 dark:bg-neutral-800"
+          style={{ top: contextMenu.y, left: contextMenu.x }}
+        >
+          <ul>
+            {contextMenu.target.type === "node" && (
+              <>
+                <li
+                  className="cursor-pointer px-2 py-1 hover:bg-neutral-100"
+                  onClick={() => {
+                    duplicateNode(contextMenu.target.id);
+                    setContextMenu(null);
+                  }}
+                >
+                  Дублировать
+                </li>
+                <li
+                  className="cursor-pointer px-2 py-1 hover:bg-neutral-100"
+                  onClick={() => {
+                    changeType(contextMenu.target.id);
+                    setContextMenu(null);
+                  }}
+                >
+                  Изменить тип
+                </li>
+                <li
+                  className="cursor-pointer px-2 py-1 hover:bg-neutral-100"
+                  onClick={() => {
+                    quickTags(contextMenu.target.id);
+                    setContextMenu(null);
+                  }}
+                >
+                  Быстрые теги
+                </li>
+                <li
+                  className="cursor-pointer px-2 py-1 hover:bg-neutral-100"
+                  onClick={() => {
+                    deleteNodes([contextMenu.target.id]);
+                    setContextMenu(null);
+                  }}
+                >
+                  Удалить
+                </li>
+              </>
+            )}
+            {contextMenu.target.type === "edge" && (
+              <li
+                className="cursor-pointer px-2 py-1 hover:bg-neutral-100"
+                onClick={() => {
+                  deleteEdges([contextMenu.target.id]);
+                  setContextMenu(null);
+                }}
+              >
+                Удалить
+              </li>
+            )}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -8,7 +8,7 @@ export function Inspector({
   updateNode,
   updateEdge,
 }: {
-  selection: { node?: Node<CRTNodeData>; edge?: Edge<CRTEdgeData> };
+  selection: { node?: Node; edge?: Edge<CRTEdgeData> };
   updateNode: (id: string, data: Partial<CRTNodeData>) => void;
   updateEdge: (id: string, patch: Partial<Edge<CRTEdgeData>>) => void;
 }) {
@@ -22,7 +22,7 @@ export function Inspector({
         <p className="text-xs text-neutral-500 dark:text-neutral-400">Ничего не выбрано. Кликните узел или связь.</p>
       )}
 
-      {node && (
+      {node && node.type === "crt" && (
         <div className="space-y-2">
           <div>
             <label className="block text-[11px] text-neutral-500">Заголовок</label>
@@ -93,7 +93,7 @@ export function Inspector({
             </select>
           </div>
           <div>
-            <label className="block text-[11px] text-neutral-500">Метка</label>
+            <label className="block text-[11px] text-neutral-500">Метка/вес</label>
             <input
               className="w-full rounded-lg border border-neutral-300 bg-white p-2 text-xs dark:border-neutral-700 dark:bg-neutral-900"
               value={edge.label?.toString() ?? ""}
@@ -101,6 +101,10 @@ export function Inspector({
             />
           </div>
         </div>
+      )}
+
+      {node && node.type === "and" && (
+        <p className="text-xs text-neutral-500 dark:text-neutral-400">Узел AND</p>
       )}
     </div>
   );

--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -1,16 +1,16 @@
 "use client";
 import type { Edge, Node } from "reactflow";
 import type { CRTNodeData, CRTNodeCategory } from "./NodeView";
-import type { CRTEdgeData, CRTEdgeKind } from "./Toolbar";
+import type { CRTEdgeKind } from "./Toolbar";
 
 export function Inspector({
   selection,
   updateNode,
   updateEdge,
 }: {
-  selection: { node?: Node; edge?: Edge<CRTEdgeData> };
+  selection: { node?: Node<CRTNodeData>; edge?: Edge };
   updateNode: (id: string, data: Partial<CRTNodeData>) => void;
-  updateEdge: (id: string, patch: Partial<Edge<CRTEdgeData>>) => void;
+  updateEdge: (id: string, patch: Partial<Edge>) => void;
 }) {
   const node = selection.node;
   const edge = selection.edge;

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -40,6 +40,11 @@ export function Toolbar({
     e.dataTransfer.effectAllowed = "move";
   };
 
+  const handleDragStartAnd = (e: React.DragEvent) => {
+    e.dataTransfer.setData("application/reactflow", JSON.stringify({ type: "and" }));
+    e.dataTransfer.effectAllowed = "move";
+  };
+
   return (
     <div className="fixed left-3 top-3 z-50 w-64 rounded-2xl border bg-white/80 p-3 shadow-xl backdrop-blur-md dark:bg-neutral-900/80 dark:border-neutral-800">
       <div className="mb-2 text-sm font-semibold uppercase text-neutral-600 dark:text-neutral-300">
@@ -57,6 +62,14 @@ export function Toolbar({
             {categoryLabel[c]}
           </div>
         ))}
+        <div
+          draggable
+          onDragStart={handleDragStartAnd}
+          className="cursor-grab select-none rounded-xl bg-neutral-900 p-2 text-center text-xs font-bold text-white shadow active:cursor-grabbing"
+          title="Перетащите на холст"
+        >
+          AND
+        </div>
       </div>
 
       <div className="mt-4 flex items-center justify-between gap-2">

--- a/src/components/ValidationPanel.tsx
+++ b/src/components/ValidationPanel.tsx
@@ -1,0 +1,136 @@
+"use client";
+import { Edge, Node, ReactFlowInstance } from "reactflow";
+import { useMemo } from "react";
+import type { CRTEdgeData } from "./Toolbar";
+import type { CRTNodeData } from "./NodeView";
+
+export type Warning = {
+  id: string;
+  label: string;
+  nodeId?: string;
+};
+
+function findCycles(nodes: Node[], edges: Edge<CRTEdgeData>[]): string[][] {
+  const adj: Record<string, string[]> = {};
+  edges.forEach((e) => {
+    (adj[e.source] ||= []).push(e.target);
+  });
+  const visited = new Set<string>();
+  const stack = new Set<string>();
+  const path: string[] = [];
+  const cycles: string[][] = [];
+  function dfs(v: string) {
+    visited.add(v);
+    stack.add(v);
+    path.push(v);
+    for (const n of adj[v] || []) {
+      if (!visited.has(n)) {
+        dfs(n);
+      } else if (stack.has(n)) {
+        const idx = path.indexOf(n);
+        if (idx !== -1) cycles.push(path.slice(idx).concat(n));
+      }
+    }
+    stack.delete(v);
+    path.pop();
+  }
+  nodes.forEach((n) => {
+    if (!visited.has(n.id)) dfs(n.id);
+  });
+  return cycles;
+}
+
+export function ValidationPanel({
+  open,
+  setOpen,
+  nodes,
+  edges,
+  rf,
+  setSelection,
+}: {
+  open: boolean;
+  setOpen: (v: boolean) => void;
+  nodes: Node[];
+  edges: Edge<CRTEdgeData>[];
+  rf: ReactFlowInstance | null;
+  setSelection: (sel: { node?: Node; edge?: Edge<CRTEdgeData> }) => void;
+}) {
+  const warnings = useMemo(() => {
+    const w: Warning[] = [];
+    const inCount: Record<string, number> = {};
+    const outCount: Record<string, number> = {};
+    edges.forEach((e) => {
+      outCount[e.source] = (outCount[e.source] || 0) + 1;
+      inCount[e.target] = (inCount[e.target] || 0) + 1;
+    });
+    nodes.forEach((n) => {
+      const inc = inCount[n.id] || 0;
+      const out = outCount[n.id] || 0;
+      if (inc === 0 && out === 0) {
+        w.push({ id: `dangling-${n.id}`, label: `Висячий узел ${n.id}`, nodeId: n.id });
+      }
+      const data = n.data as CRTNodeData | undefined;
+      if (n.type === "crt" && data) {
+        if (data.category === "UDE" && inc === 0) {
+          w.push({ id: `ude-${n.id}`, label: `UDE без причин (${n.data.title})`, nodeId: n.id });
+        }
+        if (data.category === "RootCause" && out === 0) {
+          w.push({ id: `rc-${n.id}`, label: `RootCause без следствий (${n.data.title})`, nodeId: n.id });
+        }
+      }
+      if (n.type === "and" && inc < 2) {
+        w.push({ id: `and-${n.id}`, label: `AND требует ≥2 входов`, nodeId: n.id });
+      }
+    });
+    const cycles = findCycles(nodes, edges);
+    cycles.forEach((c, i) => {
+      w.push({ id: `cycle-${i}`, label: `Цикл: ${c.join(" → ")}`, nodeId: c[0] });
+    });
+    return w;
+  }, [nodes, edges]);
+
+  const handleFocus = (id?: string) => {
+    if (!id) return;
+    const node = nodes.find((n) => n.id === id);
+    if (node) {
+      rf?.setCenter(node.position.x, node.position.y, { zoom: 1.5 });
+      setSelection({ node });
+    }
+  };
+
+  if (!open)
+    return (
+      <div
+        className="fixed bottom-3 right-3 z-50 cursor-pointer rounded-xl border bg-white/80 px-3 py-1 text-xs shadow-md backdrop-blur-md dark:border-neutral-800 dark:bg-neutral-900/80"
+        onClick={() => setOpen(true)}
+      >
+        Проверка
+      </div>
+    );
+
+  return (
+    <div className="fixed bottom-3 right-3 z-50 w-64 rounded-2xl border bg-white/80 p-3 shadow-xl backdrop-blur-md dark:border-neutral-800 dark:bg-neutral-900/80">
+      <div className="mb-2 flex items-center justify-between text-sm font-semibold uppercase text-neutral-600 dark:text-neutral-300">
+        <span>Проверка</span>
+        <button className="text-xs" onClick={() => setOpen(false)}>
+          ×
+        </button>
+      </div>
+      {warnings.length === 0 ? (
+        <p className="text-xs text-neutral-500 dark:text-neutral-400">Нет предупреждений</p>
+      ) : (
+        <ul className="space-y-1 text-xs">
+          {warnings.map((w) => (
+            <li
+              key={w.id}
+              className="cursor-pointer underline"
+              onClick={() => handleFocus(w.nodeId)}
+            >
+              {w.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/nodes/AndNode.tsx
+++ b/src/components/nodes/AndNode.tsx
@@ -1,0 +1,8 @@
+"use client";
+export default function AndNode() {
+  return (
+    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-black text-[10px] font-bold text-white">
+      AND
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add AND node type and validation panel for dangling nodes, cycles and structural mistakes
- introduce context menus, multi-selection with alignment helpers, snap grid and clipboard ops

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689da2d91cc4832bae575712c83c19a9